### PR TITLE
[Enhancement] Adding cache-writer to improve delta performance

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,56 +2,55 @@ var fs = require('fs')
 var path = require('path')
 var mkdirp = require('mkdirp')
 var includePathSearcher = require('include-path-searcher')
-var quickTemp = require('quick-temp')
-var mapSeries = require('promise-map-series')
+var CachingWriter = require('broccoli-caching-writer')
 var less = require('less')
 var _ = require('lodash')
 var RSVP = require('rsvp');
 
-module.exports = LessCompiler
+module.exports = LessCompiler;
+LessCompiler.prototype = Object.create(CachingWriter.prototype)
+LessCompiler.prototype.constructor = LessCompiler
+
 function LessCompiler (sourceTrees, inputFile, outputFile, options) {
-  if (!(this instanceof LessCompiler)) return new LessCompiler(sourceTrees, inputFile, outputFile, options)
+  if (!(this instanceof LessCompiler)) {
+    return new LessCompiler(sourceTrees, inputFile, outputFile, options)
+  }
+
+  CachingWriter.apply(this, arguments)
+
   this.sourceTrees = sourceTrees
   this.inputFile = inputFile
   this.outputFile = outputFile
   this.lessOptions = options || {}
 }
 
-LessCompiler.prototype.read = function (readTree) {
-  var self = this
-  quickTemp.makeOrRemake(this, '_tmpDestDir')
-  var destFile = this._tmpDestDir + '/' + this.outputFile
-  mkdirp.sync(path.dirname(destFile))
-  return mapSeries(this.sourceTrees, readTree)
-    .then(function (includePaths) {
-      var lessOptions = {
-        filename: includePathSearcher.findFileSync(self.inputFile, includePaths),
-        paths: includePaths,
+LessCompiler.prototype.updateCache = function (srcDir, destDir) {
+  var destFile = destDir + '/' + this.outputFile
+
+  mkdirp.sync(path.dirname(destFile));
+
+  var lessOptions = {
+    filename: includePathSearcher.findFileSync(this.inputFile, srcDir),
+    paths: srcDir
+  }
+
+  _.merge(lessOptions, this.lessOptions)
+  lessOptions.paths = [path.dirname(lessOptions.filename)].concat(lessOptions.paths);
+  data = fs.readFileSync(lessOptions.filename, 'utf8');
+
+  var parser = new(less.Parser)(lessOptions);
+
+  return new RSVP.Promise(function(resolve, reject) {
+    parser.parse(data, function (err, tree) {
+      if (err) {
+        less.writeError(err, lessOptions);
+        reject(err);
       }
-      _.merge(lessOptions, self.lessOptions)
-      lessOptions.paths = [path.dirname(lessOptions.filename)].concat(lessOptions.paths);
-      data = fs.readFileSync(lessOptions.filename, 'utf8');
 
-      var parser = new(less.Parser)(lessOptions);
+      var css = tree.toCSS(lessOptions);
+      fs.writeFileSync(destFile, css, { encoding: 'utf8' });
 
-      var promise = new RSVP.Promise(function(resolve, reject) {
-        parser.parse(data, function (e, tree) {
-          if (e) {
-            less.writeError(e, lessOptions);
-            reject(e);
-          }
-          var css = tree.toCSS(lessOptions);
-          fs.writeFileSync(destFile, css, { encoding: 'utf8' });
-
-          resolve(self._tmpDestDir);
-        });
-      });
-
-      return promise;
+      resolve();
     });
+  });
 }
-
-LessCompiler.prototype.cleanup = function () {
-  quickTemp.remove(this, '_tmpDestDir')
-}
-

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "broccoli-less-single",
   "description": "Single-file-output LESS compiler for Broccoli",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "author": {
     "name": "Gabriel Grant",
     "email": "g@briel.ca"
@@ -10,6 +10,9 @@
     {
       "name": "Jo Liss",
       "email": "joliss42@gmail.com"
+    }, {
+      "name": "Jason Mitchell",
+      "email": "jason.mitchell.w@gmail.com"
     }
   ],
   "main": "index.js",
@@ -26,11 +29,10 @@
   "dependencies": {
     "mkdirp": "^0.3.5",
     "lodash": "~2.4.1",
-    "quick-temp": "^0.1.0",
-    "promise-map-series": "^0.2.0",
     "include-path-searcher": "^0.1.0",
-    "less": "~1.6.3",
-    "rsvp": "~3.0.6"
+    "less": "1.7.5",
+    "rsvp": "~3.0.6",
+    "broccoli-caching-writer": "0.5.1"
   },
   "readmeFilename": "README.md",
   "bugs": {


### PR DESCRIPTION
This is leveraging `broccoli-caching-writer` to prevent unwarranted execution of the write function when the sourceTree(s) has not changed.

`less.toCss` is pretty big offender in terms of performance, so Caching Writer will only ever invoke the `updateCache`, previously `write`, function when needed.
