### PR TITLE
Prevent unnecessary options from being passed into cache writer

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function LessCompiler (sourceTrees, inputFile, outputFile, options) {
     return new LessCompiler(sourceTrees, inputFile, outputFile, options)
   }
 
-  CachingWriter.apply(this, arguments)
+  CachingWriter.apply(this, [arguments[0]].concat(arguments[3]))
 
   this.sourceTrees = sourceTrees
   this.inputFile = inputFile


### PR DESCRIPTION
The arguments being passed into the less compiler plugin was resulting
in string arguments (inputFile, outputFile) to become options for the
cache writer.
