### PR TITLE
Restore sourcemap support with less 2.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,17 @@ var less = require('less')
 var _ = require('lodash')
 var RSVP = require('rsvp');
 
+function writeFilePromise(filename, data, options) {
+  return new RSVP.Promise(function(resolve, reject) {
+    fs.writeFile(filename, data, options, function (err) {
+      if (err) {
+        return reject(err);
+      }
+      return resolve(data);
+    });
+  });
+}
+
 module.exports = LessCompiler;
 LessCompiler.prototype = Object.create(CachingWriter.prototype)
 LessCompiler.prototype.constructor = LessCompiler
@@ -18,10 +29,20 @@ function LessCompiler (sourceTrees, inputFile, outputFile, options) {
 
   CachingWriter.apply(this, [arguments[0]].concat(arguments[3]))
 
+  options = options || {};
+  if (options.sourceMap) {
+    if (typeof options.sourceMap !== 'object') {
+      options.sourceMap = {};
+    }
+    if (!options.sourceMap.sourceMapURL) {
+      options.sourceMap.sourceMapURL = outputFile + '.map';
+    }
+  }
+
   this.sourceTrees = sourceTrees
   this.inputFile = inputFile
   this.outputFile = outputFile
-  this.lessOptions = options || {}
+  this.lessOptions = options
 }
 
 LessCompiler.prototype.updateCache = function (srcDir, destDir) {
@@ -40,21 +61,24 @@ LessCompiler.prototype.updateCache = function (srcDir, destDir) {
 
   return new RSVP.Promise(function(resolve, reject) {
 
-    less.render(data, lessOptions)
-      .then(function (output) {
+    less.render(data, lessOptions).then(function (output) {
 
-        fs.writeFile(destFile, output.css, { encoding: 'utf8' }, function (err) {
-          if (err) {
-            return reject(err);
-          }
+      var fileWriterPromises = [ writeFilePromise(destFile, output.css, { encoding: 'utf8' }) ];
+      var sourceMapURL = lessOptions.sourceMap && lessOptions.sourceMap.sourceMapURL;
+      if (sourceMapURL) {
+        fileWriterPromises.push( writeFilePromise(destDir + '/' + sourceMapURL, output.map, { encoding: 'utf8' }) );
+      }
 
-          return resolve(output);
-        });
-
-      }, function (err) {
-        less.writeError(err, lessOptions);
-        reject(err);
+      RSVP.all(fileWriterPromises).then(function() {
+        return resolve(output);
+      }, function(err) {
+        return reject(err);
       });
+
+    }, function (err) {
+      less.writeError(err, lessOptions);
+      reject(err);
+    });
 
   });
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "mkdirp": "^0.5.0",
     "lodash": "^2.4.1",
     "include-path-searcher": "^0.1.0",
-    "less": "^2.1.1",
+    "less": "^2.5.0",
     "rsvp": "^3.0.17",
     "broccoli-caching-writer": "^0.5.4"
   },


### PR DESCRIPTION
Fixes https://github.com/gabrielgrant/broccoli-less-single/issues/23

With the upgrade to less 2.x and the `less.render` method, it appears you now need to write the sourcemap file yourself, as well as set the sourceMapURL to that file.