### PR TITLE
Fixed Source Map generation when multiple input/output paths are used.

### DIFF
--- a/test/expected/basic.css
+++ b/test/expected/basic.css
@@ -6,5 +6,5 @@
 }
 .basic-test .bar {
   font-size: 20px;
-  color: #ff0000;
+  color: #FF0000;
 }

--- a/test/expected/import.css
+++ b/test/expected/import.css
@@ -6,7 +6,7 @@
 }
 .basic-test .bar {
   font-size: 20px;
-  color: #ff0000;
+  color: #FF0000;
 }
 .class {
   width: calc(95%);


### PR DESCRIPTION
Hey there,

first of all, many thanks for the plugin.

This pull request fixes the generation of Source Maps when multiple input/output paths are used, for example in an Ember CLI app:

```javascript
var app = new EmberApp(defaults, {
  outputPaths: {
    app: {
      html: 'index.html',
      css: {
        'foo': '/assets/foo.css',
        'bar': '/assets/bar.css'
      },
      js: '/assets/app.js'
    },

    // ...
  },

  // ...
};
```

Without the pull request, for `/assets/bar.css` a Source Map with the name `/assets/foo.css.map` is created instead of `/assets/bar.css.map`.

This is probably also the reason for https://github.com/gdub22/ember-cli-less/issues/32.

Maik