### PR TITLE
Options handling if multiple input/output paths are used.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ var includePathSearcher = require('include-path-searcher')
 var CachingWriter = require('broccoli-caching-writer')
 var less = require('less')
 var merge = require('lodash-node/modern/object/merge')
-var RSVP = require('rsvp');
-var writeFile = RSVP.denodeify(fs.writeFile);
+var RSVP = require('rsvp')
+var writeFile = RSVP.denodeify(fs.writeFile)
 
 module.exports = LessCompiler;
 
@@ -20,26 +20,28 @@ function LessCompiler (sourceTrees, inputFile, outputFile, options) {
 
   CachingWriter.apply(this, [arguments[0]].concat(arguments[3]))
 
-  options = options || {};
+  options = merge({}, options)
+
   if (options.sourceMap) {
     if (typeof options.sourceMap !== 'object') {
       options.sourceMap = {};
     }
+
     if (!options.sourceMap.sourceMapURL) {
       options.sourceMap.sourceMapURL = outputFile + '.map';
     }
   }
 
   this.sourceTrees = sourceTrees
-  this.inputFile = inputFile
-  this.outputFile = outputFile
+  this.inputFile   = inputFile
+  this.outputFile  = outputFile
   this.lessOptions = options
 }
 
 LessCompiler.prototype.updateCache = function (srcDir, destDir) {
   var destFile = destDir + '/' + this.outputFile
 
-  mkdirp.sync(path.dirname(destFile));
+  mkdirp.sync(path.dirname(destFile))
 
   var lessOptions = {
     filename: includePathSearcher.findFileSync(this.inputFile, srcDir),

--- a/test/expected/basic.css
+++ b/test/expected/basic.css
@@ -6,5 +6,5 @@
 }
 .basic-test .bar {
   font-size: 20px;
-  color: #ff0000;
+  color: #FF0000;
 }

--- a/test/expected/import.css
+++ b/test/expected/import.css
@@ -6,7 +6,7 @@
 }
 .basic-test .bar {
   font-size: 20px;
-  color: #ff0000;
+  color: #FF0000;
 }
 .class {
   width: calc(95%);


### PR DESCRIPTION
Hey there,

if you use multiple input/output paths with `ember-cli-less`, multiple instances of `LESSCompiler` (`broccoli-less-single`) are created:

```javascript
var trees = Object.keys(paths).map(function(file) {
  var input  = path.join(inputPath, file + '.' + ext);
  var output = paths[file];

  return new LESSCompiler([tree], input, output, options);
});
```

The problem: The options are shared / overridden by the last instance, respectively all instances have the same options. This results in the problem, that multiple Source Maps with the same name are created.

For example:

```javascript
var app = new EmberApp(defaults, {
  outputPaths: {
    app: {
      html: 'index.html',
      css: {
        'foo': '/assets/foo.css',
        'bar': '/assets/bar.css'
      },
      js: '/assets/app.js'
    },

    // ...
  },

  // ...
};
```

For `/assets/bar.css` a Source Map with the name `/assets/foo.css.map` is created instead of `/assets/bar.css.map`.

 I fixed the problem, but i do not really understand, why this happens , and if this is the right solution.