### PR TITLE
Performance fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function LessCompiler (sourceTrees, inputFile, outputFile, options) {
   
   var cacheOptions = merge({
     filterFromCache: {
-      include: [/.*\.less$/]
+      include: [/.*\.(less|css)$/]
     }
   }, options)
 

--- a/index.js
+++ b/index.js
@@ -17,8 +17,14 @@ function LessCompiler (sourceTrees, inputFile, outputFile, options) {
   if (!(this instanceof LessCompiler)) {
     return new LessCompiler(sourceTrees, inputFile, outputFile, options)
   }
+  
+  var cacheOptions = merge({
+    filterFromCache: {
+      include: [/.*\.less$/]
+    }
+  }, options)
 
-  CachingWriter.apply(this, [arguments[0]].concat(arguments[3]))
+  CachingWriter.call(this, sourceTrees, cacheOptions)
 
   options = merge({}, options)
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test:debug": "mocha debug test/runner.js --reporter spec"
   },
   "dependencies": {
-    "broccoli-caching-writer": "^0.5.4",
+    "broccoli-caching-writer": "^1.1.0",
     "include-path-searcher": "^0.1.0",
     "less": "^2.5.0",
     "lodash.merge": "^3.3.2",


### PR DESCRIPTION
This solves the problem of the LessCompiler running on all rebuilds, even if no `.less` files
have changed.

Related to https://github.com/gdub22/ember-cli-less/issues/28
