### PR TITLE
update broccoli@^1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The broccoli-less-single plugin compiles `.less` files with
 [less.js](https://github.com/less/less.js).
 
 This plugin is designed to compile a single, primary input file
-into a single output file, with a tree of `@import`d dependencies. This
+into a single output file, with a node of `@import`d dependencies. This
 differs from [broccoli-less](https://github.com/sindresorhus/broccoli-less/),
 which compiles each `.less` file individually into a `.css` file and doesn't
 support `@import`s or a single output file depending on multiple inputs.
@@ -25,14 +25,14 @@ npm install --save-dev broccoli-less-single
 ```js
 var compileLess = require('broccoli-less-single');
 
-var outputTree = compileLess(inputTrees, inputFile, outputFile, options)
+var outputNode = compileLess(inputNodes, inputFile, outputFile, options)
 ```
 
-* **`inputTrees`**: An array of trees that act as the include paths for
-  less. If you have a single tree, pass `[tree]`.
+* **`inputNodes`**: An array of nodes that act as the include paths for
+  less. If you have a single node, pass `[node]`.
 
 * **`inputFile`**: Relative path of the main `.less` file to compile. This
-  file must exist in one of the `inputTrees`.
+  file must exist in one of the `inputNodes`.
 
 * **`outputFile`**: Relative path of the output CSS file.
 
@@ -41,7 +41,7 @@ var outputTree = compileLess(inputTrees, inputFile, outputFile, options)
 ### Example
 
 ```js
-var appCss = compileLess(sourceTrees, 'myapp/app.less', 'assets/app.css')
+var appCss = compileLess(sourceNodes, 'myapp/app.less', 'assets/app.css')
 ```
 
 ### `@import`-Example

--- a/index.js
+++ b/index.js
@@ -7,12 +7,12 @@ module.exports = LessCompiler;
 LessCompiler.prototype = Object.create(CachingWriter.prototype);
 LessCompiler.prototype.constructor = LessCompiler;
 
-function LessCompiler(sourceTrees, inputFile, outputFile, _options) {
+function LessCompiler(sourceNodes, inputFile, outputFile, _options) {
   if (!(this instanceof LessCompiler)) {
-    return new LessCompiler(sourceTrees, inputFile, outputFile, _options);
+    return new LessCompiler(sourceNodes, inputFile, outputFile, _options);
   }
 
-  CachingWriter.call(this, Array.isArray(sourceTrees) ? sourceTrees : [sourceTrees], _options);
+  CachingWriter.call(this, Array.isArray(sourceNodes) ? sourceNodes : [sourceNodes], _options);
 
   // clone the _options hash to prevent mutating what was
   // passed into us with fallback values. see issue #29
@@ -29,7 +29,7 @@ function LessCompiler(sourceTrees, inputFile, outputFile, _options) {
   }
 
   this.lessOptions = options;
-  this.sourceTrees = sourceTrees;
+  this.sourceNodes = sourceNodes;
   this.inputFile   = inputFile;
   this.outputFile  = outputFile;
 };

--- a/package.json
+++ b/package.json
@@ -36,14 +36,14 @@
     "test:debug": "mocha debug test/runner.js --reporter spec"
   },
   "dependencies": {
-    "broccoli-caching-writer": "^2.1.0",
+    "broccoli-caching-writer": "^2.3.1",
     "include-path-searcher": "^0.1.0",
     "less": "^2.5.0",
     "lodash.merge": "^3.3.2",
     "mkdirp": "^0.5.0"
   },
   "devDependencies": {
-    "broccoli": "^0.16.8",
+    "broccoli": "^1.1.0",
     "mocha": "^2.2.4",
     "rsvp": "^3.1.0"
   },

--- a/test/utils/build.js
+++ b/test/utils/build.js
@@ -8,15 +8,16 @@ var broccoli = require('broccoli');
 var compileLess = require('../../index');
 var read = require('./read');
 
-module.exports = function (inputTrees, inputFile, outputFile, lessOptions) {
-  inputTrees = !Array.isArray(inputTrees) ? [inputTrees] : inputTrees;
+module.exports = function (inputNodes, inputFile, outputFile, lessOptions) {
+  inputNodes = !Array.isArray(inputNodes) ? [inputNodes] : inputNodes;
 
-  var less = compileLess.apply(this, arguments);
+  var less = compileLess.apply(this, arguments),
+    builder = new broccoli.Builder(less);
 
-  return new broccoli.Builder(less).build().then(function (results) {
+  return builder.build().then(function () {
     return {
-      css: read(path.join(results.directory, outputFile)),
-      directory: results.directory,
+      css: read(path.join(builder.outputPath, outputFile)),
+      directory: builder.outputPath,
       outputFile: outputFile
     };
   });


### PR DESCRIPTION
Two changes,
- Bump broccoli to version 1+ and fixed tests
- Renamed `trees` -> `nodes` (suggested [cosmetic change](https://github.com/broccolijs/broccoli/blob/master/docs/broccoli-1-0-plugin-api.md#cosmetic-changes))