### PR TITLE
Fix `this.inputPaths` being removed from `lessOptions.paths`

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,16 +57,14 @@ LessCompiler.prototype.build = function() {
       this.inputFile,
       this.inputPaths
     ),
-    paths: this.inputPaths.slice()
+    paths: []
   };
-
-  this.inputPaths = lessOptions.paths.slice();
 
   require("lodash.merge")(lessOptions, this.lessOptions);
 
-  lessOptions.paths = [path.dirname(lessOptions.filename)].concat(
-    lessOptions.paths
-  );
+  lessOptions.paths = [path.dirname(lessOptions.filename)]
+    .concat(this.inputPaths)
+    .concat(lessOptions.paths);
 
   var data = fs.readFileSync(lessOptions.filename, "utf8");
 


### PR DESCRIPTION
I was seeing an issue here (https://github.com/kaliber5/ember-bootstrap/issues/133), when using the `paths` option to add some custom paths, the default paths of `this.inputPaths` were simply overridden by the `lodash.merge` call, instead of extended. I assume this behavior is not correct!? Then this should fix it.