### PR TITLE
Skip source map file when inline source maps are requested

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function LessCompiler(sourceNodes, inputFile, outputFile, _options) {
       options.sourceMap = {};
     }
 
-    if (!options.sourceMap.sourceMapURL) {
+    if (!options.sourceMap.sourceMapURL && !options.sourceMap.sourceMapFileInline) {
       options.sourceMap.sourceMapURL = outputFile + '.map';
     }
   }

--- a/tests/index.js
+++ b/tests/index.js
@@ -93,6 +93,24 @@ describe("BroccoliLessSingle", function() {
     });
   });
 
+  it("basic preprocessing + inline sourceMap", () => {
+    input.write({
+      "input.less": read("/fixtures/basic/input.less")
+    });
+
+    return this.createSubject("input.less", "input.css", {
+      sourceMap: {
+        sourceMapFileInline: true
+      }
+    }).then(out => {
+      expect(out["input.css"]).to.have.string(
+        read("/fixtures/basic/output.css") +
+          "/*# sourceMappingURL=data:application/json;base64"
+      );
+      expect(out["input.map"]).to.be.undefined;
+    })
+  });
+
   it("`import`", () => {
     input.write({
       "input.less": read("/fixtures/import/input.less"),


### PR DESCRIPTION
This PR changes the behavior of the `sourceMap` option so that a source map file will *not* be created when then `sourceMap.sourceMapFileInline` option is truthy and `sourceMap.sourceMapURL` has not been explicitly set.

This allows users to request inline source maps only.

Fixes #45